### PR TITLE
Hotfix/14346 display issue homepage

### DIFF
--- a/web/themes/custom/lgd_org_theme/css/layout.css
+++ b/web/themes/custom/lgd_org_theme/css/layout.css
@@ -136,14 +136,16 @@
 .layout--threecol-33-34-33 > .layout__region--first,
 .layout--threecol-33-34-33 > .layout__region--second,
 .layout--threecol-33-34-33 > .layout__region--third {
-    flex: 1 1 calc(calc(100% / 3) - var(--spacing-larger) * 3);
+    flex: 0 1 calc((100% - 2 * var(--spacing-larger)) / 3);
+    min-width: 0;
   }
 }
 
 @media screen and (min-width: 40rem) {
 .layout--twocol > .layout__region--first,
 .layout--twocol > .layout__region--second {
-    flex: 1 1 calc(50% - var(--spacing-larger) * 2);
+    flex: 0 1 calc((100% - var(--spacing-larger)) / 2);
+    min-width: 0;
   }
 }
 

--- a/web/themes/custom/lgd_org_theme/css/variables.css
+++ b/web/themes/custom/lgd_org_theme/css/variables.css
@@ -228,7 +228,7 @@ body {
   /* Call-out Box */
   --call-out-box-text-color: var(--color-black);
   --call-out-box-bg-color: transparent;
-  --call-out-box-padding: 2rem 3rem 1.5rem;
+  --call-out-box-padding: clamp(1rem, 3vw, 2rem) clamp(1.5rem, 4vw, 3rem) clamp(1rem, 2vw, 1.5rem);
 
   --featured-teaser-border: 0;
 


### PR DESCRIPTION
**Problem: Columns were disappearing due to flex calculation.**

  Solution:
  - Changed flex: 1 1 calc(...) to flex: 0 1 calc(...)
    - Setting flex-grow to 0 prevents columns from expanding beyond their calculated size
    - Simplified gap calculation: (100% - 2 * gap) / 3 for 3-column and (100% - gap) / 2 for 2-column
  layouts
  - Added min-width: 0 to allow columns to shrink properly when content overflows

  **2. Call-Out Box Padding Fix (variables.css:231)**

  Problem: Fixed padding caused overlapping when zooming the browser.

  Solution:
  - Replaced fixed padding 2rem 3rem 1.5rem with responsive clamp() values:
    - Top: clamp(1rem, 3vw, 2rem) - scales from 1rem to 2rem based on viewport
    - Right/Left: clamp(1.5rem, 4vw, 3rem) - scales from 1.5rem to 3rem
    - Bottom: clamp(1rem, 2vw, 1.5rem) - scales from 1rem to 1.5rem
NB: at 200% there is a strange overlap of borders, but the text is readable